### PR TITLE
tutorial/Eureka: fix healthcheck instructions

### DIFF
--- a/tutorial/Eureka.md
+++ b/tutorial/Eureka.md
@@ -21,7 +21,7 @@ Everything from the Health Check URL to the port numbers can stay the same, just
 
 1. Naviate to Asgard. This can be done by finding the DNS Name from the end of [Step 13](AsgardStandalone.md) or finding the Asgard ELB and using the DNS Name.
 2. Follow "Create Application", using the name "eureka" instead of "asgard".
-3. Follow "Create an ELB", using the name "eureka" instead of "asgard". And instead of HTTP:7001/healthcheck for the Health Check URL, use "HTTP:7001/api/v2/view/instances;_limit=1". The protocol and port are the same, but the path is different.
+3. Follow "Create an ELB", using the name "eureka" instead of "asgard".
 4. Follow "Create Auto Scaling Group" using the name "eureka" instead of "asgard".
 5. Follow "View instance" to get the DNS Name for eureka's ELB, i.e. _eureka--frontend_. It can Eureka quite a few minutes to start up, because it is trying find other instances.
 6. Using that DNS Name, visit _http://*ELB DNS name*/_. ![](images/Eureka.png)


### PR DESCRIPTION
Eureka does have a healthcheck endpoint (/healthcheck). The "HTTP:7001/api/v2/view/instances;_limit=1" thing seems to be a copy-paste issue, because it's the URL used for the Edda project.

Since it's the same endpoint as Asgard, I believe it's safe to just instruct users to follow asgard instructions, replacing only the name.
