### PR TITLE
Fixes related to making zerotocloud work with the latest Karyon

### DIFF
--- a/karyon/build.gradle
+++ b/karyon/build.gradle
@@ -1,46 +1,47 @@
 
 import zerotocloud.*
 task cloneRepo(type: CloneRepo) {
-    repository = 'https://github.com/Netflix/karyon.git'
+  repository = 'https://github.com/Netflix/karyon.git'
+
 }
 
 task patchRepo {
-    dependsOn 'cloneRepo'
+  dependsOn 'cloneRepo'
     doFirst {
-        def app = new File(cloneRepo.gitDir, 'karyon-examples/src/main/java/com/netflix/karyon/examples/hellonoss/server/jersey/JerseyHelloWorldApp.java')
+      def app = new File(cloneRepo.gitDir, 'karyon-examples/src/main/java/com/netflix/karyon/examples/hellonoss/server/jersey/JerseyHelloWorldApp.java')
         def contents = app.text
         app.withWriter { out ->
-            out << contents
-                    .replace('import com.netflix.karyon.servo.KaryonServoModule;', 'import com.netflix.karyon.servo.KaryonServoModule;\nimport com.netflix.karyon.eureka.KaryonEurekaModule;')
-                    .replace('// KaryonEurekaModule.class,', 'KaryonEurekaModule.class, ')
-                    // It's impossible to test REST calls from a browser if a HTTP Header is required.
-                    .replace('interceptorSupport().forUri("/hello").interceptIn(AuthInterceptor.class);', '//interceptorSupport().forUri("/hello").interceptIn(AuthInterceptor.class);')
+          out << contents
+            .replace('import com.netflix.karyon.servo.KaryonServoModule;', 'import com.netflix.karyon.servo.KaryonServoModule;\nimport com.netflix.karyon.eureka.KaryonEurekaModule;')
+            .replace('// KaryonEurekaModule.class,', 'KaryonEurekaModule.class, ')
+            // It's impossible to test REST calls from a browser if a HTTP Header is required.
+            .replace('interceptorSupport().forUri("/hello").interceptIn(AuthInterceptor.class);', '//interceptorSupport().forUri("/hello").interceptIn(AuthInterceptor.class);')
         }
 
-        def scanning = new File(cloneRepo.gitDir, 'karyon-examples/src/main/resources/hello-netflix-oss.properties')
+      def scanning = new File(cloneRepo.gitDir, 'karyon-examples/src/main/resources/hello-netflix-oss.properties')
         def scanContents = scanning.text
         scanning.withWriter { out ->
-            // Let jersey scan Eureka package for healthcheck
-            out << scanContents.replace('com.netflix.karyon.examples.hellonoss', 'com.netflix.karyon.examples.hellonoss,com.netflix.appinfo')
+          // Let jersey scan Eureka package for healthcheck
+          out << scanContents.replace('com.netflix.karyon.examples.hellonoss', 'com.netflix.karyon.examples.hellonoss,com.netflix.appinfo')
         }
 
-	def mc = new File(cloneRepo.gitDir, 'karyon-examples/build.gradle')
-	def mcContents = mc.text
-	mc.withWriter { out -> 
-	     // need to rewire
-		out << mcContents.replace("apply plugin: 'application'", "apply plugin: 'application'\nmainClassName = 'com.netflix.karyon.KaryonRunner'")
-	}
+      def mc = new File(cloneRepo.gitDir, 'karyon-examples/build.gradle')
+        def mcContents = mc.text
+        mc.withWriter { out -> 
+          // need to rewire
+          out << mcContents.replace("apply plugin: 'application'", "apply plugin: 'application'\nmainClassName = 'com.netflix.karyon.KaryonRunner'")
+        }
     }
 }
 
 task patchEndpoint {
-    dependsOn 'cloneRepo'
+  dependsOn 'cloneRepo'
     doFirst {
-        def app = new File(cloneRepo.gitDir, 'karyon-examples/src/main/java/com/netflix/karyon/examples/hellonoss/server/jersey/HelloworldResource.java')
+      def app = new File(cloneRepo.gitDir, 'karyon-examples/src/main/java/com/netflix/karyon/examples/hellonoss/server/jersey/HelloworldResource.java')
         def contents = app.text
         app.withWriter { out ->
-            out << contents
-                    .replace('Netflix OSS', 'Zero to Cloud Developers!')
+          out << contents
+            .replace('Netflix OSS', 'Zero to Cloud Developers!')
         }
 
     }
@@ -55,14 +56,14 @@ task buildRepo(type: Build) {
 
 import org.apache.tools.ant.filters.*
 ospackage {
-    def dist = new File(buildRepo.moduleDir, 'karyon-examples/build/distributions/karyon-examples-2.1.00-RC7.zip')
+  def dist = new File(buildRepo.moduleDir, 'karyon-examples/build/distributions/karyon-examples-2.1.00-RC7.zip')
     from( zipTree(dist) ) {
-        into('/opt')
+      into('/opt')
     }
-    from(file('root')) {
-        into('/')
-        filter ReplaceTokens, tokens: [ 'KARYON_OPTS': System.getenv('KARYON_OPTS') ?: '' ]
-    }
-    postInstall('echo manual > /etc/init/tomcat7.override')
+  from(file('root')) {
+    into('/')
+      filter ReplaceTokens, tokens: [ 'KARYON_OPTS': System.getenv('KARYON_OPTS') ?: '' ]
+  }
+  postInstall('echo manual > /etc/init/tomcat7.override')
 }
 buildDeb.dependsOn(buildRepo)

--- a/karyon/root/etc/init/karyon.conf
+++ b/karyon/root/etc/init/karyon.conf
@@ -7,5 +7,5 @@ env enabled=1
 respawn
 
 env JAVA_OPTS="-Xmx2560m -Djava.awt.headless=true -Deureka.name=karyon -Deureka.region=us-west-2 -Deureka.port=80 -Deureka.us-west-2.availabilityZones=default @KARYON_OPTS@"
-exec start-stop-daemon --start --chuid ubuntu --chdir /opt/karyon-examples-2.1.00-RC6/ \
---exec /opt/karyon-examples-2.1.00-RC6/bin/karyon-examples -- com.netflix.karyon.examples.hellonoss.server.jersey.JerseyHelloWorldApp
+exec start-stop-daemon --start --chuid ubuntu --chdir /opt/karyon-examples-2.1.00-RC7/ \
+--exec /opt/karyon-examples-2.1.00-RC7/bin/karyon-examples -- com.netflix.karyon.examples.hellonoss.server.jersey.JerseyHelloWorldApp


### PR DESCRIPTION
- latest karyon has split its examples into multiple directories. multiple fixes related to running Jersey example
- make patchEndpoint a true build dependency  
