### PR TITLE
Update build.gradle

### DIFF
--- a/asgard/build.gradle
+++ b/asgard/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'war'
 
 import de.undercouch.gradle.tasks.download.Download
 task download(type: Download) {
-    src 'https://github.com/Netflix/asgard/releases/download/asgard-1.5/asgard.war'
+    src 'https://github.com/Netflix/asgard/releases/download/1.5.1/asgard.war'
     onlyIfNewer true
     dest new File(buildDir, 'asgard.war')
 }


### PR DESCRIPTION
Updated download src to grab "Asgard 1.5.1 - Emergency Maintenance Release" WAR file

Amazon have updated their pricing JSON, which breaks Asgard's cache populators. The 1.5.1 release resolves that issue.